### PR TITLE
[d] feat: Add the @MODULON_SKIP tag to allow skip importing a module

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -56,7 +56,8 @@ let
           content = builtins.readFile file;
         in
         # Check if any pattern exists in the content
-        builtins.any (pattern: lib.strings.hasInfix pattern content) moduleDetection;
+        !(lib.strings.hasInfix "# @MODULON_SKIP" content)
+        && builtins.any (pattern: lib.strings.hasInfix pattern content) moduleDetection;
 
       # Recursively collect .nix files from a directory
       collectModulesRec =


### PR DESCRIPTION
Until now, the only way to skip modules has been to add them to the excludePaths list. With this tag checker, you can now easily tell Modulon to skip specific modules without modifying the exclusion list. :)

This is especially useful when you have a module structure like this:

```shell
.
├── ...
├── packages
│   ├── cli.nix
│   ├── default.nix
│   ├── gui.nix
│   └── tryout.nix
└── ...
```

Without this new functionality, you'd need to do something like this in your flake:

```nix
...
# Dynamically import NixOS modules
(libModulon {
  dirs = [ "${self}/configs/nixos/modules" ];
  excludePaths = [
    "/applications/packages/"
  ];
  extraModules = [
    "${self}/configs/nixos/modules/applications/packages/default.nix"
  ];
})
...
```

Just add `@MODULON_SKIP` anywhere in your module (I recommend adding it at the top), and you're good to go!